### PR TITLE
Address heap compatibility feedback

### DIFF
--- a/shim/bindings_kernel32.c
+++ b/shim/bindings_kernel32.c
@@ -43,6 +43,7 @@ BOOL __stdcall h_HeapDestroy(HANDLE hHeap) {
 }
 
 BOOL __stdcall h_HeapValidate(HANDLE hHeap, DWORD dwFlags, LPCVOID lpMem) {
+    hHeap = FixHeap(hHeap, lpMem);
     if (UseOurHeap(hHeap, lpMem)) {
         // Use the working code's fallback approach
         return TRUE; // Our heap is always valid

--- a/shim/bindings_ntdll.c
+++ b/shim/bindings_ntdll.c
@@ -18,28 +18,46 @@ PVOID NTAPI h_RtlAllocateHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN SIZE_T Si
 }
 
 PVOID NTAPI h_RtlReAllocateHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN LPVOID Address, IN SIZE_T Size) {
-    if (_IsOurHeap(HeapHandle)) {
-        return HeapReAlloc(HeapHandle, Flags, Address, Size);
+    LPVOID uRet = NULL;
+    HeapHandle = FixHeap(HeapHandle, Address);
+    dprintf("h_HeapReAlloc\n");
+    if (UseOurHeap(HeapHandle, Address)) {
+        uRet = HeapReAlloc(HeapHandle, Flags, Address, Size);
     }
     else {
-        return o_RtlReAllocateHeap ? o_RtlReAllocateHeap(HeapHandle, Flags, Address, Size) : NULL;
+        if (ValidateNTHeap(HeapHandle, Address)) {
+            uRet = o_RtlReAllocateHeap ? o_RtlReAllocateHeap(HeapHandle, Flags, Address, Size) : NULL;
+        }
     }
+    return uRet;
 }
 
 BOOLEAN NTAPI h_RtlFreeHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN PVOID Address) {
-    if (_IsOurHeap(HeapHandle)) {
-        return HeapFree(HeapHandle, Flags, Address);
+    BOOL bRet = FALSE;
+    HeapHandle = FixHeap(HeapHandle, Address);
+    dprintf("h_HeapFree\n");
+    if (UseOurHeap(HeapHandle, Address)) {
+        bRet = HeapFree(HeapHandle, Flags, Address);
     }
     else {
-        return o_RtlFreeHeap ? o_RtlFreeHeap(HeapHandle, Flags, Address) : FALSE;
+        if (ValidateNTHeap(HeapHandle, Address)) {
+            bRet = o_RtlFreeHeap ? o_RtlFreeHeap(HeapHandle, Flags, Address) : FALSE;
+        }
     }
+    return bRet;
 }
 
 SIZE_T NTAPI h_RtlSizeHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN PVOID Address) {
-    if (_IsOurHeap(HeapHandle)) {
-        return HeapSize(HeapHandle, Flags, Address);
+    SIZE_T bRet = 0;
+    HeapHandle = FixHeap(HeapHandle, Address);
+    dprintf("h_HeapSize\n");
+    if (UseOurHeap(HeapHandle, Address)) {
+        bRet = HeapSize(HeapHandle, Flags, Address);
     }
     else {
-        return o_RtlSizeHeap ? o_RtlSizeHeap(HeapHandle, Flags, Address) : 0;
+        if (ValidateNTHeap(HeapHandle, Address)) {
+            bRet = o_RtlSizeHeap ? o_RtlSizeHeap(HeapHandle, Flags, Address) : 0;
+        }
     }
+    return bRet;
 }


### PR DESCRIPTION
Implement `FixHeap` logic in heap functions to prevent crashes when reallocating, freeing, or sizing memory not originally allocated by the emulated heap.

This change addresses a critical compatibility issue where programs might call heap functions on `GetProcessHeap()` for memory allocated by the real NT heap before the 9xheap emulation library was loaded. Without `FixHeap`, the emulated heap would attempt to process these requests and fail, leading to crashes. The `FixHeap` logic ensures these operations are correctly redirected to the original NT heap. Debug logging was also added for consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-0999219b-e02e-41bb-a433-d8f2297cabe5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0999219b-e02e-41bb-a433-d8f2297cabe5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

