### PR TITLE
Address heap compatibility feedback

### DIFF
--- a/shim/bindings_kernel32.c
+++ b/shim/bindings_kernel32.c
@@ -43,9 +43,9 @@ BOOL __stdcall h_HeapDestroy(HANDLE hHeap) {
 }
 
 BOOL __stdcall h_HeapValidate(HANDLE hHeap, DWORD dwFlags, LPCVOID lpMem) {
+    hHeap = FixHeap(hHeap, lpMem);
     if (UseOurHeap(hHeap, lpMem)) {
-        // Use the working code's fallback approach
-        return TRUE; // Our heap is always valid
+        return TRUE;
     }
     return o_HeapValidate ? o_HeapValidate(hHeap, dwFlags, lpMem) : FALSE;
 }

--- a/shim/bindings_ntdll.c
+++ b/shim/bindings_ntdll.c
@@ -9,37 +9,32 @@ tRtlFreeHeap* o_RtlFreeHeap = NULL;
 tRtlSizeHeap* o_RtlSizeHeap = NULL;
 
 PVOID NTAPI h_RtlAllocateHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN SIZE_T Size) {
-    if (_IsOurHeap(HeapHandle)) {
-        return HeapAlloc(HeapHandle, Flags, Size);
+    if (UseOurHeap(HeapHandle, NULL)) {
+        return _HeapAlloc(HeapHandle, Flags, Size);
     }
-    else {
-        return o_RtlAllocateHeap ? o_RtlAllocateHeap(HeapHandle, Flags, Size) : NULL;
-    }
+    return o_RtlAllocateHeap ? o_RtlAllocateHeap(HeapHandle, Flags, Size) : NULL;
 }
 
 PVOID NTAPI h_RtlReAllocateHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN LPVOID Address, IN SIZE_T Size) {
-    if (_IsOurHeap(HeapHandle)) {
-        return HeapReAlloc(HeapHandle, Flags, Address, Size);
+    HeapHandle = FixHeap(HeapHandle, Address);
+    if (UseOurHeap(HeapHandle, Address)) {
+        return _HeapReAlloc(HeapHandle, Flags, Address, Size);
     }
-    else {
-        return o_RtlReAllocateHeap ? o_RtlReAllocateHeap(HeapHandle, Flags, Address, Size) : NULL;
-    }
+    return o_RtlReAllocateHeap ? o_RtlReAllocateHeap(HeapHandle, Flags, Address, Size) : NULL;
 }
 
 BOOLEAN NTAPI h_RtlFreeHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN PVOID Address) {
-    if (_IsOurHeap(HeapHandle)) {
-        return HeapFree(HeapHandle, Flags, Address);
+    HeapHandle = FixHeap(HeapHandle, Address);
+    if (UseOurHeap(HeapHandle, Address)) {
+        return _HeapFree(HeapHandle, Flags, Address);
     }
-    else {
-        return o_RtlFreeHeap ? o_RtlFreeHeap(HeapHandle, Flags, Address) : FALSE;
-    }
+    return o_RtlFreeHeap ? o_RtlFreeHeap(HeapHandle, Flags, Address) : FALSE;
 }
 
 SIZE_T NTAPI h_RtlSizeHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN PVOID Address) {
-    if (_IsOurHeap(HeapHandle)) {
-        return HeapSize(HeapHandle, Flags, Address);
+    HeapHandle = FixHeap(HeapHandle, Address);
+    if (UseOurHeap(HeapHandle, Address)) {
+        return _HeapSize(HeapHandle, Flags, Address);
     }
-    else {
-        return o_RtlSizeHeap ? o_RtlSizeHeap(HeapHandle, Flags, Address) : 0;
-    }
+    return o_RtlSizeHeap ? o_RtlSizeHeap(HeapHandle, Flags, Address) : 0;
 }

--- a/shim/bindings_ntdll.h
+++ b/shim/bindings_ntdll.h
@@ -5,7 +5,7 @@
 typedef PVOID NTAPI tRtlAllocateHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN SIZE_T Size);
 typedef PVOID NTAPI tRtlReAllocateHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN LPVOID Address, IN SIZE_T Size);
 typedef BOOLEAN NTAPI tRtlFreeHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN PVOID Address);
-typedef ULONG NTAPI tRtlSizeHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN PVOID Address);
+typedef SIZE_T NTAPI tRtlSizeHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN PVOID Address);
 
 extern tRtlAllocateHeap* o_RtlAllocateHeap;
 extern tRtlReAllocateHeap* o_RtlReAllocateHeap;
@@ -15,4 +15,4 @@ extern tRtlSizeHeap* o_RtlSizeHeap;
 PVOID NTAPI h_RtlAllocateHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN SIZE_T Size);
 PVOID NTAPI h_RtlReAllocateHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN LPVOID Address, IN SIZE_T Size);
 BOOLEAN NTAPI h_RtlFreeHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN PVOID Address);
-ULONG NTAPI h_RtlSizeHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN PVOID Address);
+SIZE_T NTAPI h_RtlSizeHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN PVOID Address);


### PR DESCRIPTION
Integrate `FixHeap` into NTDLL heap hooks and `HeapValidate` to correctly handle pre-existing heap allocations and prevent crashes.

`FixHeap` was previously defined but unused in key NTDLL heap hooks and `HeapValidate`. This caused crashes when programs operated on memory allocated by the system heap *before* 9xheap emulation loaded. Integrating `FixHeap` ensures these operations correctly dispatch to the original system functions, improving compatibility. `RtlSizeHeap` type was also corrected to `SIZE_T`.

---
<a href="https://cursor.com/background-agent?bcId=bc-68b1a5f3-cd79-4445-bbe4-a1d7c6e64e0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-68b1a5f3-cd79-4445-bbe4-a1d7c6e64e0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

