### PR TITLE
Address heap compatibility feedback

### DIFF
--- a/shim/bindings_kernel32.c
+++ b/shim/bindings_kernel32.c
@@ -43,11 +43,18 @@ BOOL __stdcall h_HeapDestroy(HANDLE hHeap) {
 }
 
 BOOL __stdcall h_HeapValidate(HANDLE hHeap, DWORD dwFlags, LPCVOID lpMem) {
+    BOOL bRet = FALSE;
+    hHeap = FixHeap(hHeap, lpMem);
     if (UseOurHeap(hHeap, lpMem)) {
         // Use the working code's fallback approach
-        return TRUE; // Our heap is always valid
+        bRet = TRUE; // Our heap is always valid
     }
-    return o_HeapValidate ? o_HeapValidate(hHeap, dwFlags, lpMem) : FALSE;
+    else {
+        if (ValidateNTHeap(hHeap, lpMem)) {
+            bRet = o_HeapValidate ? o_HeapValidate(hHeap, dwFlags, lpMem) : FALSE;
+        }
+    }
+    return bRet;
 }
 
 SIZE_T __stdcall h_HeapCompact(HANDLE hHeap, DWORD dwFlags) {

--- a/shim/bindings_ntdll.c
+++ b/shim/bindings_ntdll.c
@@ -18,28 +18,43 @@ PVOID NTAPI h_RtlAllocateHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN SIZE_T Si
 }
 
 PVOID NTAPI h_RtlReAllocateHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN LPVOID Address, IN SIZE_T Size) {
-    if (_IsOurHeap(HeapHandle)) {
-        return HeapReAlloc(HeapHandle, Flags, Address, Size);
+    LPVOID uRet = NULL;
+    HeapHandle = FixHeap(HeapHandle, Address);
+    if (UseOurHeap(HeapHandle, Address)) {
+        uRet = _HeapReAlloc(HeapHandle, Flags, Address, Size);
     }
     else {
-        return o_RtlReAllocateHeap ? o_RtlReAllocateHeap(HeapHandle, Flags, Address, Size) : NULL;
+        if (ValidateNTHeap(HeapHandle, Address)) {
+            uRet = o_RtlReAllocateHeap(HeapHandle, Flags, Address, Size);
+        }
     }
+    return uRet;
 }
 
 BOOLEAN NTAPI h_RtlFreeHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN PVOID Address) {
-    if (_IsOurHeap(HeapHandle)) {
-        return HeapFree(HeapHandle, Flags, Address);
+    BOOL bRet = FALSE;
+    HeapHandle = FixHeap(HeapHandle, Address);
+    if (UseOurHeap(HeapHandle, Address)) {
+        bRet = _HeapFree(HeapHandle, Flags, Address);
     }
     else {
-        return o_RtlFreeHeap ? o_RtlFreeHeap(HeapHandle, Flags, Address) : FALSE;
+        if (ValidateNTHeap(HeapHandle, Address)) {
+            bRet = o_RtlFreeHeap(HeapHandle, Flags, Address);
+        }
     }
+    return bRet;
 }
 
 SIZE_T NTAPI h_RtlSizeHeap(IN HANDLE HeapHandle, IN ULONG Flags, IN PVOID Address) {
-    if (_IsOurHeap(HeapHandle)) {
-        return HeapSize(HeapHandle, Flags, Address);
+    SIZE_T bRet = 0;
+    HeapHandle = FixHeap(HeapHandle, Address);
+    if (UseOurHeap(HeapHandle, Address)) {
+        bRet = _HeapSize(HeapHandle, Flags, Address);
     }
     else {
-        return o_RtlSizeHeap ? o_RtlSizeHeap(HeapHandle, Flags, Address) : 0;
+        if (ValidateNTHeap(HeapHandle, Address)) {
+            bRet = o_RtlSizeHeap(HeapHandle, Flags, Address);
+        }
     }
+    return bRet;
 }


### PR DESCRIPTION
Integrate `FixHeap` into NTDLL and Kernel32 heap hook functions to prevent crashes in mixed heap scenarios.

Previously, `HeapRealloc`, `HeapFree`, `HeapSize`, and `HeapValidate` could fail if called on a pointer allocated by the real process heap before 9xheap was loaded, as the hooked `GetProcessHeap()` would return the emulated heap handle. `FixHeap` detects these cases and redirects the operation to the original process heap.

---
<a href="https://cursor.com/background-agent?bcId=bc-58376c5b-4596-42c5-971c-c18cb46d0b73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-58376c5b-4596-42c5-971c-c18cb46d0b73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

